### PR TITLE
fix(deps): update pywin32 version specification in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ Pygments==2.19.1
 pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 pytz==2025.2
-pywin32==310
+pywin32
 pyzmq==26.4.0
 referencing==0.36.2
 requests==2.32.3


### PR DESCRIPTION
Removes the specific version pinning for pywin32 in requirements.txt.   This change allows for more flexibility in dependency resolution and   ensures compatibility with future updates of the library.