### PR TITLE
chore:Removed `pywin32` from `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,6 @@ Pygments==2.19.1
 pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 pytz==2025.2
-pywin32
 pyzmq==26.4.0
 referencing==0.36.2
 requests==2.32.3


### PR DESCRIPTION
- Merged `origin/master` into `p-branch-1`
- Removed `pywin32` from `requirements.txt` to streamline project dependencies for non-Windows environments.